### PR TITLE
Display bass note in chord

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -52,6 +52,10 @@ impl std::fmt::Display for Chord {
             write!(f, "{}", self.number)?;
         }
 
+        if self.bass != self.root {
+            write!(f, "/{}", self.bass)?;
+        }
+
         Ok(())
     }
 }


### PR DESCRIPTION
The Display implementation for Chord didn't include the bass note. So for example C/F would be displayed as C.